### PR TITLE
feat(88): :sparkles: add reading time

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -175,5 +175,6 @@ module.exports = {
         path: `${__dirname}/content/blog`,
       },
     },
+    `gatsby-remark-reading-time`
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "gatsby-remark-external-links": "0.0.4",
         "gatsby-remark-footnotes": "0.0.8",
         "gatsby-remark-images": "^3.3.9",
+        "gatsby-remark-reading-time": "^1.1.0",
         "gatsby-remark-responsive-iframe": "^2.1.1",
         "gatsby-remark-smartypants": "^2.0.9",
         "gatsby-remark-vscode": "^2.1.2",
@@ -12942,6 +12943,17 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/gatsby-remark-reading-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-reading-time/-/gatsby-remark-reading-time-1.1.0.tgz",
+      "integrity": "sha512-J2I/Aerw6iEcYUs9MH5r7Ky5PIe7Aiq7+M3sDWdRa0ddWYIOZGxPq8U1xYsIBwQjVtPovk8N4aMTau9kjQQLQA==",
+      "dependencies": {
+        "reading-time": "^1.1.3"
+      },
+      "peerDependencies": {
+        "gatsby": "^2.0.0"
+      }
+    },
     "node_modules/gatsby-remark-responsive-iframe": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-2.11.0.tgz",
@@ -19364,6 +19376,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reading-time": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg=="
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
@@ -33323,6 +33340,14 @@
         }
       }
     },
+    "gatsby-remark-reading-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-reading-time/-/gatsby-remark-reading-time-1.1.0.tgz",
+      "integrity": "sha512-J2I/Aerw6iEcYUs9MH5r7Ky5PIe7Aiq7+M3sDWdRa0ddWYIOZGxPq8U1xYsIBwQjVtPovk8N4aMTau9kjQQLQA==",
+      "requires": {
+        "reading-time": "^1.1.3"
+      }
+    },
     "gatsby-remark-responsive-iframe": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-2.11.0.tgz",
@@ -37914,6 +37939,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "reading-time": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg=="
     },
     "recursive-readdir": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gatsby-remark-external-links": "0.0.4",
     "gatsby-remark-footnotes": "0.0.8",
     "gatsby-remark-images": "^3.3.9",
+    "gatsby-remark-reading-time": "^1.1.0",
     "gatsby-remark-responsive-iframe": "^2.1.1",
     "gatsby-remark-smartypants": "^2.0.9",
     "gatsby-remark-vscode": "^2.1.2",

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -17,10 +17,33 @@ const getFeatureImgPath = featuredImg => {
   }
 }
 
+const translateReadingTime = stats => {
+  if (!stats) {
+    return "Unknown";
+  }
+
+  const minutes = Math.ceil(stats?.minutes || 0);
+  let readingTimeText = '';
+
+  switch (true) {
+    case minutes < 1:
+    readingTimeText = 'menos de 1 minuto';
+      break;
+    case minutes === 1:
+    readingTimeText = '1 minuto';
+      break;
+    default:
+    readingTimeText = `${minutes} minutos`;
+      break;
+  }
+  return readingTimeText;
+}
+
 class BlogPostTemplate extends React.Component {
   render() {
     const post = this.props.data.mdx
     const { previous, next } = this.props.pageContext
+    const { fields } = post
 
     const disqusConfig = {
       url: this.props.location.href,
@@ -52,6 +75,17 @@ class BlogPostTemplate extends React.Component {
           }}
         >
           {post.frontmatter.date}
+        </p>
+
+        <p
+          style={{
+            ...scale(-1 / 5),
+            display: `block`,
+            marginBottom: rhythm(1),
+            marginTop: rhythm(-1),
+          }}
+        >
+          <strong>Tempo de leitura: {translateReadingTime(fields.readingTime)}</strong>
         </p>
         <MDXRenderer>{post.body}</MDXRenderer>
         <hr
@@ -114,6 +148,12 @@ export const pageQuery = graphql`
           childImageSharp {
             gatsbyImageData(layout: FULL_WIDTH)
           }
+        }
+      }
+      fields {
+        readingTime {
+          text
+          minutes
         }
       }
     }


### PR DESCRIPTION
This pull request adds the reading time property to a blog written with Gatsby.
The reading time is automatically calculated using the
gatsby-remark-reading-time plugin, making it easier for readers to estimate the
time it will take them to read the blog. This feature is useful for improving
user experience and providing readers with a better understanding of the length
of the blog. 
