### PR TITLE
fix: add autoplay to 'Últimos Posts' carousel

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -63,6 +63,7 @@ class IndexPage extends React.Component {
           title="Últimos Posts" 
           icon={faFire}
           count={5}
+          autoplay={true}
         />
 
         <SidebarSection>


### PR DESCRIPTION
This PR adds autoplay to the 'Últimos Posts' carousel to match the 'Posts em Destaque' carousel behavior. Both carousels will now auto-advance every 5 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled autoplay functionality for the recent posts carousel, automatically advancing through content without user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->